### PR TITLE
kernel/timeconst.pl: Can't use 'defined(@array)' (Maybe you should just omit the defined()?) 

### DIFF
--- a/hw/imx507/linux-2.6.35.3-USBHOST/kernel/timeconst.pl
+++ b/hw/imx507/linux-2.6.35.3-USBHOST/kernel/timeconst.pl
@@ -369,10 +369,8 @@ if ($hz eq '--can') {
 		die "Usage: $0 HZ\n";
 	}
 
-	@val = @{$canned_values{$hz}};
-	if (!defined(@val)) {
-		@val = compute_values($hz);
-	}
+	$cv = $canned_values{$hz};
+	@val = defined($cv) ? @$cv : compute_values($hz);
 	output($hz, @val);
 }
 exit 0;


### PR DESCRIPTION
Hello. I got this error trying to build kernel:

```
% make CROSS_COMPILE=arm-none-linux-gnueabi- ARCH=arm uImage
  CHK     include/linux/version.h
  CHK     include/generated/utsrelease.h
make[1]: 'include/generated/mach-types.h' is up to date.
  CALL    scripts/checksyscalls.sh
  CHK     include/generated/compile.h
  TIMEC   kernel/timeconst.h
perl: warning: Falling back to a fallback locale ("en_US.UTF-8").
Can't use 'defined(@array)' (Maybe you should just omit the defined()?) at kernel/timeconst.pl line 373.
/home/temoto/XCSoar-Kobo-Build/hw/imx507/linux-2.6.35.3-USBHOST/kernel/Makefile:138: recipe for target 'kernel/timeconst.h' failed
make[1]: *** [kernel/timeconst.h] Error 255
Makefile:884: recipe for target 'kernel' failed
make: *** [kernel] Error 2
```

My Perl version: 5.24.1 (Debian 9)
Relevant issue found on web: https://bugzilla.mozilla.org/show_bug.cgi?id=1231340
Patch source: https://bug1231340.bmoattachments.org/attachment.cgi?id=8697580

With patch it works fine.